### PR TITLE
Update osmosis version and docker permission

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   osmosisd:
-    image: osmolabs/osmosis:7.1.0
+    image: osmolabs/osmosis:7.3.0
     user: "${UID}:${GID}"
     volumes:
       - ./config:/osmosis/.osmosisd/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3"
 
 services:
   osmosisd:
-    image: osmolabs/osmosis:7.3.0
-    user: "${UID}:${GID}"
+    image: osmolabs/osmosis:8.0.0
+    user: "root:root"
     volumes:
       - ./config:/osmosis/.osmosisd/config
       - ./data:/osmosis/.osmosisd/data


### PR DESCRIPTION
This PR:

- Update osmosis to `8.0.0`
- Remove the warning about empty `UID:GID` when running `docker-compose up` setting user and group to `root`

```
WARNING: The UID variable is not set. Defaulting to a blank string.
WARNING: The GID variable is not set. Defaulting to a blank string.
```