### PR TITLE
Update osmosis version and remove sudo command from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CURRENT_GID := $(shell id -g)
 start:
 	env UID=${CURRENT_UID} GID=${CURRENT_GID}  docker-compose up
 
+startd:
+	env UID=${CURRENT_UID} GID=${CURRENT_GID}  docker-compose up -d
+
 stop:
 	docker-compose stop
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
+CURRENT_UID := $(shell id -u)
+CURRENT_GID := $(shell id -g)
+
 start:
-	sudo docker-compose up
+	env UID=${CURRENT_UID} GID=${CURRENT_GID}  docker-compose up
 
 stop:
-	sudo docker-compose stop
+	docker-compose stop
 
-restart:
-	sudo docker-compose rm
-	rm -r ./data/*
+reset:
+	docker-compose rm
+	rm -rf ./data/ || true 
+	mkdir -p ./data/
 	cp priv_validator_state.json ./data
+
+restart: reset start

--- a/README.md
+++ b/README.md
@@ -163,3 +163,47 @@ LocalOsmosis is pre-configured with one validator and 10 accounts with ION and O
 | test8     | `osmo1f4tvsdukfwh6s9swrc24gkuz23tp8pd3e9r5fa`                                                           | `cream sport mango believe inhale text fish rely elegant below earth april wall rug ritual blossom cherry detail length blind digital proof identify ride`                 |
 | test9     | `osmo1myv43sqgnj5sm4zl98ftl45af9cfzk7nhjxjqh`                                                           | `index light average senior silent limit usual local involve delay update rack cause inmate wall render magnet common feature laundry exact casual resource hundred`       |
 | test10    | `osmo14gs9zqh8m49yy9kscjqu9h72exyf295afg6kgk`                                                           | `prefer forget visit mistake mixture feel eyebrow autumn shop pair address airport diesel street pass vague innocent poem method awful require hurry unhappy shoulder`     |
+
+## Common issues
+
+### Docker permissions problems
+
+In case you get permission denied while trying to run `make start`
+
+```
+make start
+
+Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.40/containers/json: dial unix /var/run/docker.sock: connect: permission denied
+```
+
+**Check that the docker engine is running:**
+
+```bash
+sudo systemctl status docker
+```
+
+If not:
+
+```bash
+# Configure Docker to start on boot
+sudo systemctl enable docker.service
+
+# Start docker service
+sudo systemctl start docker.service
+```
+
+**Ensure that the current user is in the `docker` group:**
+
+1. Create the docker group and add your user
+
+```bash
+# Create the docker group
+sudo groupadd docker
+
+# Add your user to the docker group.
+sudo usermod -aG docker $USER
+```
+
+2. Log out and log back in so that your group membership is re-evaluated.
+
+More details can be found [here](https://docs.docker.com/engine/install/linux-postinstall/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   osmosisd:
     image: osmolabs/osmosis:10.0.1
-    user: "root:root"
+    user: $UID-$GID
     volumes:
       - ./config:/osmosis/.osmosisd/config
       - ./data:/osmosis/.osmosisd/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   osmosisd:
     image: osmolabs/osmosis:10.0.1
-    user: $UID-$GID
+    user: $UID:$GID
     volumes:
       - ./config:/osmosis/.osmosisd/config
       - ./data:/osmosis/.osmosisd/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   osmosisd:
-    image: osmolabs/osmosis:9.0.0
+    image: osmolabs/osmosis:10.0.1
     user: "root:root"
     volumes:
       - ./config:/osmosis/.osmosisd/config


### PR DESCRIPTION
This PR:

- Updates the osmosis version to the latest (I have noted to automate this step with a new osmosis release)

- Remove the need of running the `docker-compose` command with `sudo` priviliges using the `UID` and `GID` environment variables. As a result, the `data` folder will have the same permission of the current user. I have tested this in different  environments but please verify that you don't have permission problems.  

- I have renamed the `restart` command to `reset` as the `restart` wouldn't actually restart localOsmosis. I created a new `restart` command which is basically `reset` + `start`.

- Added `startd` command to run `docker-compose` in detached mode
